### PR TITLE
Add Drive Letter To Snapshot Description

### DIFF
--- a/3-ebs-snapshot.ps1
+++ b/3-ebs-snapshot.ps1
@@ -52,7 +52,8 @@ function prereqcheck {
 # Snapshot all volumes attached to this instance.
 function snapshot_volumes {
 	foreach($volume_id in $volume_list)	{
-		$description="$hostname-backup-$today"
+		$letter = get_drive_letter($volume_id)
+		$description="$hostname-$letter-backup-$today"
 		$global:log_message = $global:log_message + "Volume ID is $volume_id" + $nl
     
 		# Take a snapshot of the current volume, and capture the resulting snapshot ID
@@ -84,6 +85,55 @@ function cleanup_snapshots {
 			}
 		}
 	}
+}
+
+function get_drive_letter($volId) {
+    # Much of this function was pulled from Powershell code in the AWS documentation at
+    # http://docs.aws.amazon.com/AWSEC2/latest/WindowsGuide/ec2-windows-volumes.html
+    # Get the drive letter for the volume ID that was passed in
+
+    # Create a hash table that maps each device to a SCSI target
+    $Map = @{"0" = '/dev/sda1'} 
+    for($x = 1; $x -le 26; $x++) {$Map.add($x.ToString(), [String]::Format("xvd{0}",[char](97 + $x)))}
+    for($x = 78; $x -le 102; $x++) {$Map.add($x.ToString(), [String]::Format("xvdc{0}",[char](19 + $x)))}
+
+    #Get the volumes attached to this instance
+    $BlockDeviceMappings = (Get-EC2Instance -Region $region -Instance $instance_id).Instances.BlockDeviceMappings
+
+    $drives = Get-WmiObject -Class Win32_DiskDrive | % {
+        $Drive = $_
+        # Find the partitions for this drive
+        Get-WmiObject -Class Win32_DiskDriveToDiskPartition |  Where-Object {$_.Antecedent -eq $Drive.Path.Path} | %{
+            $D2P = $_
+            # Get details about each partition
+            $Partition = Get-WmiObject -Class Win32_DiskPartition |  Where-Object {$_.Path.Path -eq $D2P.Dependent}
+            # Find the drive that this partition is linked to
+            $Disk = Get-WmiObject -Class Win32_LogicalDiskToPartition | Where-Object {$_.Antecedent -in $D2P.Dependent} | %{ 
+                $L2P = $_
+                #Get the drive letter for this partition, if there is one
+                Get-WmiObject -Class Win32_LogicalDisk | Where-Object {$_.Path.Path -in $L2P.Dependent}
+            }
+            $BlockDeviceMapping = $BlockDeviceMappings | Where-Object {$_.DeviceName -eq $Map[$Drive.SCSITargetId.ToString()]}
+           
+            # Display the information in a table
+            New-Object PSObject -Property @{
+                Device = $Map[$Drive.SCSITargetId.ToString()];
+                Disk = [Int]::Parse($Partition.Name.Split(",")[0].Replace("Disk #",""));
+                Boot = $Partition.BootPartition;
+                Partition = [Int]::Parse($Partition.Name.Split(",")[1].Replace(" Partition #",""));
+                SCSITarget = $Drive.SCSITargetId;
+                DriveLetter = If($Disk -eq $NULL) {"NA"} else {$Disk.DeviceID};
+                VolumeName = If($Disk -eq $NULL) {"NA"} else {$Disk.VolumeName};
+                VolumeId = If($BlockDeviceMapping -eq $NULL) {"NA"} else {$BlockDeviceMapping.Ebs.VolumeId}
+            }
+        }
+    }
+    foreach ($d in $drives) {
+        if ($volId -eq $d.VolumeId) {
+            $driveletter = $d.DriveLetter
+        }
+    }
+    return $driveletter
 }
 
 ## START COMMANDS

--- a/3-ebs-snapshot.ps1
+++ b/3-ebs-snapshot.ps1
@@ -142,7 +142,7 @@ function get_drive_letter($volId) {
 logsetup
 prereqcheck
 
-$volume_list = aws ec2 describe-volumes --filters Name="attachment.instance-id,Values=$instance_id" --query Volumes[].VolumeId --output text | %{$_.split("`t")}
+$volume_list = aws ec2 describe-volumes --region $region --filters Name="attachment.instance-id,Values=$instance_id" --query Volumes[].VolumeId --output text | %{$_.split("`t")}
 
 snapshot_volumes
 cleanup_snapshots

--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ Pull requests greatly welcomed!
                 "ec2:CreateTags",
                 "ec2:DeleteSnapshot",
                 "ec2:DescribeSnapshots",
-                "ec2:DescribeVolumes"
+                "ec2:DescribeVolumes",
+                "ec2:DescribeInstances"
             ],
             "Resource": [
                 "*"


### PR DESCRIPTION
I've added some functionality that will add the drive letter of the volume being snapshotted to the description, making it a bit easier to identify the exact EBS volume in the event you need to recover a snapshot. I've tested this in my AWS account and it works good, let me know if there's additional validation you'd want to see. Much of this code is pulled from a script in the AWS documentation, but modified slightly to fit in with these scripts. 

I also had to add the ec2:DescribeInstances permission to the policy in order for this to work, since the additional code calls Get-EC2Instance to enumerate the block device mappings. I don't think there's any more restrictive permissions to give, but let me know if there is another one we could use. 

Great set of scripts by the way!

Thanks!
Jason
